### PR TITLE
fix: resource_monitor_alarm_policy - verify filters length

### DIFF
--- a/tencentcloud/resource_tc_monitor_alarm_policy.go
+++ b/tencentcloud/resource_tc_monitor_alarm_policy.go
@@ -435,12 +435,14 @@ func resourceTencentMonitorAlarmPolicyCreate(d *schema.ResourceData, meta interf
 			}
 			if m["filter"] != nil {
 				filters := m["filter"].([]interface{})
-				filter := filters[0].(map[string]interface{})
-				alarmPolicyFilter := monitor.AlarmPolicyFilter{
-					Type:       helper.String(filter["type"].(string)),
-					Dimensions: helper.String(filter["dimensions"].(string)),
+				if len(filters) != 0 {
+					filter := filters[0].(map[string]interface{})
+					alarmPolicyFilter := monitor.AlarmPolicyFilter{
+						Type:       helper.String(filter["type"].(string)),
+						Dimensions: helper.String(filter["dimensions"].(string)),
+					}
+					alarmPolicyRule.Filter = &alarmPolicyFilter
 				}
-				alarmPolicyRule.Filter = &alarmPolicyFilter
 			}
 
 			if m["description"] != nil {


### PR DESCRIPTION
fix resource_monitor_alarm_policy panic:

```
2021-12-15T16:05:29.133+0800 [DEBUG] provider.terraform-provider-tencentcloud_v1.60.18: PANIC: runtime error: index out of range [0] with length 0
2021-12-15T16:05:29.133+0800 [DEBUG] provider.terraform-provider-tencentcloud_v1.60.18:
2021-12-15T16:05:29.133+0800 [DEBUG] provider.terraform-provider-tencentcloud_v1.60.18: goroutine 66 [running]:
2021-12-15T16:05:29.133+0800 [DEBUG] provider.terraform-provider-tencentcloud_v1.60.18: github.com/tencentcloudstack/terraform-provider-tencentcloud/tencentcloud.resourceTencentMonitorAlarmPolicyCreate(0x14000718620, {0x105ec5360, 0x140005644b0})
2021-12-15T16:05:29.133+0800 [DEBUG] provider.terraform-provider-tencentcloud_v1.60.18: 	terraform-provider-tencentcloud/tencentcloud/resource_tc_monitor_alarm_policy.go:438 +0x2e20
```